### PR TITLE
Fix broken markdown links in docs/readme.md

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -22,9 +22,9 @@ Ready to contribute? We need your help to build the future of ethical connection
 
 To set up a local development environment and start contributing:
 
-1.  **Follow the [Quickstart Guide](quickstart_guide.md).** This provides step-by-step instructions.
+1.  **Follow the [Quickstart Guide](docs/guides/implementation_guides/mvp_implementation_guide.md).** This provides step-by-step instructions.
 
-For a more comprehensive overview of the project, including our core values, architecture, and contribution guidelines, please see the full [Onboarding Guide](onboarding_guide.md).
+For a more comprehensive overview of the project, including our core values, architecture, and contribution guidelines, please see the full [Onboarding Guide](docs/core/onboarding_guide.md).
 
 ## Technology Stack
 
@@ -36,7 +36,7 @@ For a more comprehensive overview of the project, including our core values, arc
 
 ## Contributing
 
-We welcome contributions from everyone! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for detailed instructions on how to get involved. We especially encourage contributions that:
+We welcome contributions from everyone! Please see our [CONTRIBUTING.md](docs/core/contributing.md) file for detailed instructions on how to get involved. We especially encourage contributions that:
 
 *   Improve the UI/UX and accessibility: Help us make ThinkAlike a joy to use for everyone.
 *   Enhance the data traceability features: Contribute to the core of our ethical commitment by building visualizations and tools that empower users to understand their data.


### PR DESCRIPTION
Update broken markdown links in `docs/readme.md`.

* Update the link `Quickstart Guide` to `docs/guides/implementation_guides/mvp_implementation_guide.md`.
* Update the link `Onboarding Guide` to `docs/core/onboarding_guide.md`.
* Update the link `CONTRIBUTING.md` to `docs/core/contributing.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EosLumina/--ThinkAlike--/pull/2?shareId=6d284c25-aef6-41b5-9a44-24b01a417eda).