### PR TITLE
Fix import paths in test files

### DIFF
--- a/tests/test_ai_tools.py
+++ b/tests/test_ai_tools.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from ai_application_developer import AIApplicationDeveloper
+from backend.app.development.ai_application_developer import AIApplicationDeveloper
 
 
 class TestAIApplicationDeveloper(unittest.TestCase):

--- a/tests/test_doc_parser.py
+++ b/tests/test_doc_parser.py
@@ -1,6 +1,6 @@
 import unittest
 
-from doc_parser import (create_doc_list, extract_code_comments,
+from backend.app.documentation.doc_parser import (create_doc_list, extract_code_comments,
                         transform_markdown)
 
 

--- a/tests/test_ethical_compliance.py
+++ b/tests/test_ethical_compliance.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
-from ethical_validator import (EthicalDataset, log_error,
+from backend.app.verification.ethical_validator import (EthicalDataset, log_error,
                                validate_ethical_requirements)
 
 
@@ -10,10 +10,10 @@ class TestEthicalCompliance(unittest.TestCase):
     """Test suite for the validate_ethical_requirements function in
     test_ethical_compliance.py."""
 
-    @patch("ethical_validator.pd.read_csv")
-    @patch("ethical_validator.EthicalDataset.validate_biased_language")
-    @patch("ethical_validator.EthicalDataset.validate_sensitive_data")
-    @patch("ethical_validator.log_error")
+    @patch("backend.app.verification.ethical_validator.pd.read_csv")
+    @patch("backend.app.verification.ethical_validator.EthicalDataset.validate_biased_language")
+    @patch("backend.app.verification.ethical_validator.EthicalDataset.validate_sensitive_data")
+    @patch("backend.app.verification.ethical_validator.log_error")
     def test_validate_ethical_requirements_pass(
         self,
         mock_log_error,
@@ -32,10 +32,10 @@ class TestEthicalCompliance(unittest.TestCase):
         self.assertTrue(result)
         mock_log_error.assert_not_called()
 
-    @patch("ethical_validator.pd.read_csv")
-    @patch("ethical_validator.EthicalDataset.validate_biased_language")
-    @patch("ethical_validator.EthicalDataset.validate_sensitive_data")
-    @patch("ethical_validator.log_error")
+    @patch("backend.app.verification.ethical_validator.pd.read_csv")
+    @patch("backend.app.verification.ethical_validator.EthicalDataset.validate_biased_language")
+    @patch("backend.app.verification.ethical_validator.EthicalDataset.validate_sensitive_data")
+    @patch("backend.app.verification.ethical_validator.log_error")
     def test_validate_ethical_requirements_biased_language(
         self,
         mock_log_error,
@@ -54,10 +54,10 @@ class TestEthicalCompliance(unittest.TestCase):
         self.assertFalse(result)
         mock_log_error.assert_not_called()
 
-    @patch("ethical_validator.pd.read_csv")
-    @patch("ethical_validator.EthicalDataset.validate_biased_language")
-    @patch("ethical_validator.EthicalDataset.validate_sensitive_data")
-    @patch("ethical_validator.log_error")
+    @patch("backend.app.verification.ethical_validator.pd.read_csv")
+    @patch("backend.app.verification.ethical_validator.EthicalDataset.validate_biased_language")
+    @patch("backend.app.verification.ethical_validator.EthicalDataset.validate_sensitive_data")
+    @patch("backend.app.verification.ethical_validator.log_error")
     def test_validate_ethical_requirements_sensitive_data(
         self,
         mock_log_error,
@@ -78,8 +78,8 @@ class TestEthicalCompliance(unittest.TestCase):
         self.assertFalse(result)
         mock_log_error.assert_not_called()
 
-    @patch("ethical_validator.pd.read_csv", side_effect=FileNotFoundError)
-    @patch("ethical_validator.log_error")
+    @patch("backend.app.verification.ethical_validator.pd.read_csv", side_effect=FileNotFoundError)
+    @patch("backend.app.verification.ethical_validator.log_error")
     def test_validate_ethical_requirements_file_not_found(
         self, mock_log_error, mock_read_csv
     ):
@@ -89,8 +89,8 @@ class TestEthicalCompliance(unittest.TestCase):
         self.assertFalse(result)
         mock_log_error.assert_called_with(f"File not found: {file_path}")
 
-    @patch("ethical_validator.pd.read_csv", side_effect=pd.errors.EmptyDataError)
-    @patch("ethical_validator.log_error")
+    @patch("backend.app.verification.ethical_validator.pd.read_csv", side_effect=pd.errors.EmptyDataError)
+    @patch("backend.app.verification.ethical_validator.log_error")
     def test_validate_ethical_requirements_empty_data(
         self, mock_log_error, mock_read_csv
     ):
@@ -101,9 +101,9 @@ class TestEthicalCompliance(unittest.TestCase):
         mock_log_error.assert_called_with(f"No data: {file_path} is empty.")
 
     @patch(
-        "test_ethical_compliance.pd.read_csv", side_effect=Exception("Unexpected error")
+        "tests.test_ethical_compliance.pd.read_csv", side_effect=Exception("Unexpected error")
     )
-    @patch("test_ethical_compliance.log_error")
+    @patch("tests.test_ethical_compliance.log_error")
     def test_validate_ethical_requirements_unexpected_error(
         self, mock_log_error, mock_read_csv
     ):

--- a/tests/test_value_based_matcher.py
+++ b/tests/test_value_based_matcher.py
@@ -1,0 +1,100 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from backend.app.services.value_based_matcher import ValueBasedMatcher
+
+# Mock profile class for testing
+class MockProfile:
+    def __init__(self, ethical_values=None, political_values=None,
+                spiritual_values=None, lifestyle_values=None,
+                practical_values=None, interests=None):
+        self.ethical_values = ethical_values or []
+        self.political_values = political_values or []
+        self.spiritual_values = spiritual_values or []
+        self.lifestyle_values = lifestyle_values or []
+        self.practical_values = practical_values or []
+        self.interests = interests or []
+
+class TestValueBasedMatcher:
+    """Test suite for the ValueBasedMatcher class"""
+
+    @pytest.fixture
+    def db_session(self):
+        """Create a mock database session"""
+        return MagicMock()
+
+    @pytest.fixture
+    def matcher(self, db_session):
+        """Create a ValueBasedMatcher instance with mock db session"""
+        return ValueBasedMatcher(db_session)
+
+    def test_empty_profiles_return_zero_compatibility(self, matcher):
+        """Test that empty profiles return zero compatibility"""
+        profile1 = MockProfile()
+        profile2 = MockProfile()
+
+        result = matcher.calculate_compatibility(profile1, profile2)
+
+        assert result["score"] == 0.0
+        assert len(result["shared_values"]) == 0
+        assert "Insufficient" in result["description"]
+
+    def test_identical_profiles_return_high_compatibility(self, matcher):
+        """Test that identical profiles return high compatibility"""
+        ethical_values = ["honesty", "compassion", "integrity"]
+        political_values = ["equality", "freedom", "justice"]
+        interests = ["reading", "hiking", "philosophy"]
+
+        profile1 = MockProfile(
+            ethical_values=ethical_values,
+            political_values=political_values,
+            interests=interests
+        )
+        profile2 = MockProfile(
+            ethical_values=ethical_values,
+            political_values=political_values,
+            interests=interests
+        )
+
+        result = matcher.calculate_compatibility(profile1, profile2)
+
+        assert result["score"] == 1.0
+        assert set(result["shared_values"]) == set(ethical_values + political_values)
+        assert set(result["shared_interests"]) == set(interests)
+        assert "Exceptional" in result["description"]
+
+    def test_partially_overlapping_profiles(self, matcher):
+        """Test profiles with partial value overlap"""
+        profile1 = MockProfile(
+            ethical_values=["honesty", "compassion"],
+            political_values=["equality", "freedom"],
+            interests=["reading", "hiking"]
+        )
+        profile2 = MockProfile(
+            ethical_values=["honesty", "integrity"],
+            political_values=["freedom", "justice"],
+            interests=["hiking", "philosophy"]
+        )
+
+        result = matcher.calculate_compatibility(profile1, profile2)
+
+        assert 0.3 < result["score"] < 0.7  # Should be moderate compatibility
+        assert "honesty" in result["shared_values"]
+        assert "freedom" in result["shared_values"]
+        assert "hiking" in result["shared_interests"]
+
+    def test_different_value_weights(self, matcher):
+        """Test that different value categories have different weights"""
+        # Only ethical values in common (highest weight)
+        profile1 = MockProfile(ethical_values=["honesty", "compassion"])
+        profile2 = MockProfile(ethical_values=["honesty", "compassion"])
+
+        ethical_result = matcher.calculate_compatibility(profile1, profile2)
+
+        # Only practical values in common (lowest weight)
+        profile3 = MockProfile(practical_values=["organization", "punctuality"])
+        profile4 = MockProfile(practical_values=["organization", "punctuality"])
+
+        practical_result = matcher.calculate_compatibility(profile3, profile4)
+
+        # Ethical values should have a stronger impact
+        assert ethical_result["score"] > practical_result["score"]


### PR DESCRIPTION
Update import paths in test files to use fully qualified package paths.

* **tests/test_ethical_compliance.py**
  - Update import path for `EthicalDataset` and `log_error` to `backend.app.verification.ethical_validator`.
  - Update import paths in `@patch` decorators to `backend.app.verification.ethical_validator`.

* **tests/test_ai_tools.py**
  - Update import path for `AIApplicationDeveloper` to `backend.app.development.ai_application_developer`.

* **tests/test_doc_parser.py**
  - Update import path for functions to `backend.app.documentation.doc_parser`.

* **tests/test_value_based_matcher.py**
  - Add new test file with import path for `ValueBasedMatcher` from `backend.app.services.value_based_matcher`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EosLumina/--ThinkAlike--/pull/19?shareId=5e743f0f-515e-4480-9acd-b7a6539f3e32).